### PR TITLE
perf: replace `x,y` with `left,top`

### DIFF
--- a/src/composables.ts
+++ b/src/composables.ts
@@ -13,8 +13,6 @@ export function useElementBounding(
     left: 0,
     right: 0,
     top: 0,
-    x: 0,
-    y: 0,
     update,
     listen,
     pause,
@@ -33,8 +31,6 @@ export function useElementBounding(
       left,
       right,
       top,
-      x,
-      y,
     } = el.getBoundingClientRect()
     Object.assign(rect, {
       height,
@@ -43,8 +39,6 @@ export function useElementBounding(
       left,
       right,
       top,
-      x,
-      y,
     })
   }
   const raf = useRafFn(update, { immediate: false })

--- a/src/core.ts
+++ b/src/core.ts
@@ -34,7 +34,7 @@ export const StarportCraft = defineComponent({
         top: 0,
         width: `${rect.width ?? 0}px`,
         height: `${rect.height ?? 0}px`,
-        transform: `translate3d(${rect.x ?? 0}px,${rect.y ?? 0}px,0px)`,
+        transform: `translate3d(${rect.left ?? 0}px,${rect.top ?? 0}px,0px)`,
       }
       if (!sp.value.isVisible || !sp.value.el) {
         return {


### PR DESCRIPTION
x === left 
y === top
[mdn web docs - getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
![image](https://user-images.githubusercontent.com/22708432/163310576-e4e4e6dc-9ce6-4a30-bc3c-f6373465fc10.png)
