### PR TITLE
fix:  keep `Starport` created order

### DIFF
--- a/src/components/Starport.ts
+++ b/src/components/Starport.ts
@@ -15,6 +15,9 @@ export const Starport = defineComponent({
   props: proxyProps,
   setup(props, ctx) {
     const globalState = inject(InjectionGlobalState)
+    if (!globalState)
+      return
+    const { isCarrierReady } = globalState
 
     function init() {
       const state = inject(InjectionState)
@@ -23,21 +26,20 @@ export const Starport = defineComponent({
         throw new Error('[Vue Starport] Failed to find <StarportCarrier>, have you initialized it?')
     }
 
+    const _unWatch = watch(() => isCarrierReady, nVal => nVal && init())
+
     onMounted(() => {
+      // avoiding forgeting to create <StarportCarrier> component
       setTimeout(() => {
-        // avoiding forgeting to create <StarportCarrier> component
-        if (!globalState?.isCarrierReady.value)
+        if (!isCarrierReady.value)
           init()
+
+        _unWatch()
       })
     })
 
-    watch(() => globalState?.isCarrierReady, (nVal) => {
-      if (nVal)
-        init()
-    })
-
     return () => {
-      if (!globalState?.isCarrierReady.value)
+      if (!isCarrierReady.value)
         return null
 
       const slots = ctx.slots.default?.()

--- a/src/components/Starport.ts
+++ b/src/components/Starport.ts
@@ -1,6 +1,6 @@
 import { isObject } from '@vueuse/core'
 import type { DefineComponent } from 'vue'
-import { defineComponent, h, inject, isVNode, markRaw, watch } from 'vue'
+import { defineComponent, h, inject, isVNode, markRaw, onMounted, watch } from 'vue'
 import { InjectionGlobalState, InjectionState } from '../constants'
 import { proxyProps } from '../options'
 import type { StarportProps } from '../types'
@@ -22,6 +22,14 @@ export const Starport = defineComponent({
       if (!state)
         throw new Error('[Vue Starport] Failed to find <StarportCarrier>, have you initialized it?')
     }
+
+    onMounted(() => {
+      setTimeout(() => {
+        // avoiding forgeting to create <StarportCarrier> component
+        if (!globalState?.isCarrierReady.value)
+          init()
+      })
+    })
 
     watch(() => globalState?.isCarrierReady, (nVal) => {
       if (nVal)

--- a/src/components/StarportCarrier.ts
+++ b/src/components/StarportCarrier.ts
@@ -1,6 +1,6 @@
 import type { DefineComponent } from 'vue'
 import { defineComponent, getCurrentInstance, h, inject } from 'vue'
-import { InjectionOptions, InjectionState } from '../constants'
+import { InjectionGlobalState, InjectionOptions, InjectionState } from '../constants'
 import { createInternalState } from '../state'
 import { StarportCraft } from './StarportCraft'
 
@@ -14,6 +14,7 @@ export const StarportCarrier = defineComponent({
     const state = createInternalState(inject(InjectionOptions, {}))
     const app = getCurrentInstance()!.appContext.app
     app.provide(InjectionState, state)
+    inject(InjectionGlobalState)?.ready()
 
     return () => {
       return [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 import type { InjectionKey } from 'vue'
 import type { StarportOptions } from './types'
-import type { InternalState } from './state'
+import type { GlobalState, InternalState } from './state'
 
 export const InjectionState = 'vue-starport-injection' as unknown as InjectionKey<InternalState>
 export const InjectionOptions = 'vue-starport-options' as unknown as InjectionKey<StarportOptions>
+export const InjectionGlobalState = 'vue-starport-global-state' as unknown as InjectionKey<GlobalState>

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,12 +1,14 @@
 import type { Plugin } from 'vue'
 import { Starport } from './components/Starport'
 import { StarportCarrier } from './components/StarportCarrier'
-import { InjectionOptions } from './constants'
+import { InjectionGlobalState, InjectionOptions } from './constants'
+import { createGlobalState } from './state'
 import type { StarportOptions } from './types'
 
 export function StarportPlugin(defaultOptions: StarportOptions = {}): Plugin {
   return {
     install(app) {
+      app.provide(InjectionGlobalState, createGlobalState())
       app.provide(InjectionOptions, defaultOptions)
       app.component('Starport', Starport)
       app.component('StarportCarrier', StarportCarrier)

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,4 @@
-import { reactive, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
 import type { Component } from 'vue'
 import type { StarportOptions } from './types'
 import type { StarportInstance } from './instance'
@@ -31,11 +31,13 @@ export function createInternalState(options: StarportOptions) {
 export type InternalState = ReturnType<typeof createInternalState>
 
 export function createGlobalState() {
-  const isCarrierReady = ref(false)
+  const _isCarrierReady = ref(false)
 
   function ready() {
-    isCarrierReady.value = true
+    _isCarrierReady.value = true
   }
+
+  const isCarrierReady = computed(() => _isCarrierReady.value || false)
 
   return {
     isCarrierReady,

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,4 +1,4 @@
-import { reactive } from 'vue'
+import { reactive, ref } from 'vue'
 import type { Component } from 'vue'
 import type { StarportOptions } from './types'
 import type { StarportInstance } from './instance'
@@ -28,5 +28,19 @@ export function createInternalState(options: StarportOptions) {
     getInstance,
   }
 }
-
 export type InternalState = ReturnType<typeof createInternalState>
+
+export function createGlobalState() {
+  const isCarrierReady = ref(false)
+
+  function ready() {
+    isCarrierReady.value = true
+  }
+
+  return {
+    isCarrierReady,
+    ready,
+  }
+}
+
+export type GlobalState = ReturnType<typeof createGlobalState>


### PR DESCRIPTION
[link this issue](https://github.com/antfu/vue-starport/issues/36)

keep `Starport` created after `StarportCarrier` created