### PR TITLE
fix: proxy margin and padding from rect

### DIFF
--- a/src/components/StarportCraft.ts
+++ b/src/components/StarportCraft.ts
@@ -37,6 +37,8 @@ export const StarportCraft = defineComponent({
         top: 0,
         width: `${rect.width}px`,
         height: `${rect.height}px`,
+        margin: rect.margin,
+        padding: rect.padding,
         transform: `translate3d(${rect.left}px,${rect.top}px,0px)`,
       }
       if (!sp.value.isVisible || !sp.value.el) {

--- a/src/composables.ts
+++ b/src/composables.ts
@@ -14,6 +14,8 @@ export function useElementBounding(
     update,
     listen,
     pause,
+    margin: '0px',
+    padding: '0px',
   })
 
   let scope: EffectScope | undefined
@@ -26,7 +28,10 @@ export function useElementBounding(
     if (!el)
       return
     const { height, width, left, top } = el.getBoundingClientRect()
-    Object.assign(rect, { height, width, left, top: root!.scrollTop + top })
+    const domStyle = window.getComputedStyle(el)
+    const margin = domStyle.margin
+    const padding = domStyle.padding
+    Object.assign(rect, { height, width, left, top: root!.scrollTop + top, margin, padding })
   }
   const raf = useRafFn(update, { immediate: false })
 


### PR DESCRIPTION
Starport-start-A => Starport-end-B

If A has margin or padding, but B does not. Misalignment occurs before or at the end of the transition animation.
Because left/top does not add margin and padding.

eg: gif
![fixed-margin](https://user-images.githubusercontent.com/22311475/173515549-6c234e07-7f68-465b-b292-b19247eea020.gif)
