### PR TITLE
fix: StarportCraft margin caused errors in the coordinates

### DIFF
--- a/src/components/StarportCraft.ts
+++ b/src/components/StarportCraft.ts
@@ -39,7 +39,7 @@ export const StarportCraft = defineComponent({
         height: `${rect.height}px`,
         margin: rect.margin,
         padding: rect.padding,
-        transform: `translate3d(${rect.left}px,${rect.top}px,0px)`,
+        transform: `translate3d(calc(${rect.left}px - ${rect.marginLeft}),calc(${rect.top}px - ${rect.marginTop}),0px)`,
       }
       if (!sp.value.isVisible || !sp.value.el) {
         return {

--- a/src/composables.ts
+++ b/src/composables.ts
@@ -14,6 +14,8 @@ export function useElementBounding(
     update,
     listen,
     pause,
+    marginTop: '0px',
+    marginLeft: '0px',
     margin: '0px',
     padding: '0px',
   })
@@ -29,9 +31,11 @@ export function useElementBounding(
       return
     const { height, width, left, top } = el.getBoundingClientRect()
     const domStyle = window.getComputedStyle(el)
+    const marginTop = domStyle.marginTop
+    const marginLeft = domStyle.marginLeft
     const margin = domStyle.margin
     const padding = domStyle.padding
-    Object.assign(rect, { height, width, left, top: root!.scrollTop + top, margin, padding })
+    Object.assign(rect, { height, width, left, top: root!.scrollTop + top, marginTop, marginLeft, margin, padding })
   }
   const raf = useRafFn(update, { immediate: false })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I think the problem is relate on this #48 

Although StarportCraft is now setting margin correctly, it caused an error in calculating the final displacement.

You can see images jump a bit when they land

### Additional context

![Sep-07-2023 21-47-34](https://github.com/antfu/vue-starport/assets/48744981/811603b1-2e98-4bc2-a2fd-eda5be17c85e)

