### PR TITLE
fix: disable `inheritAttrs` in `StartportCarrier`

### DIFF
--- a/src/components/StarportCarrier.ts
+++ b/src/components/StarportCarrier.ts
@@ -10,6 +10,7 @@ import { StarportCraft } from './StarportCraft'
  */
 export const StarportCarrier = defineComponent({
   name: 'StarportCarrier',
+  inheritAttrs: false,
   setup(_, { slots }) {
     const state = createInternalState(inject(InjectionOptions, {}))
     const app = getCurrentInstance()!.appContext.app


### PR DESCRIPTION
### Description

Fixes the following warning during development: 

```
[Vue warn]: Extraneous non-props attributes (data-v-inspector) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes. 
  at <StarportCarrier data-v-inspector="app/layouts/default.vue:7:9" >
  ```
